### PR TITLE
Changed 'utm_campaignid' to 'utm_id', since 'utm_id' is the valid par…

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ const ADD_TO_CAMPAIGN_FINAL_URL_SUFFIX = false;
 
 //////////////////////////////////// END CUSTOMIZABLE PARAMETERS ////////////////////////////////////////////////////////////
 
-const FINAL_URL_SUFFIX_TRACKER = `utm_source=google&utm_source_platform=Google+Ads&utm_medium=cpc&utm_campaign={_${CAMPAIGN_NAME_CUSTOM_PARAMETER}}&utm_campaignid={campaignid}`;
+const FINAL_URL_SUFFIX_TRACKER = `utm_source=google&utm_source_platform=Google+Ads&utm_medium=cpc&utm_campaign={_${CAMPAIGN_NAME_CUSTOM_PARAMETER}}&utm_id={campaignid}`;
 const CUSTOM_PARAMETER_NAME_CHECK = new RegExp("^[a-zA-Z0-9]{1,16}$");
 
 /**
@@ -183,3 +183,4 @@ function replaceInvalidSymbolsInCampaignName_(campaignName){
   }
   return newCampaignName.replace(/[^a-zA-Z0-9|;_\/^(!]/g, "_");
 }
+


### PR DESCRIPTION
'utm_campaignid' doesn't work as intended in GA4.
'utm_id' is the valid UTM parameter to pass the campaign ID to GA4. https://support.google.com/analytics/answer/10917952?hl=en