### PR TITLE
Correct utm_campaignid to utm_id in README for GA4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We strongly recommend you to schedule it every day.
 1. Navigate in the Google Ads account, and go in the Account setting section.
 2. There you’ll find a “Tracking” setting.
 3. Here you can find the Final URL suffix field.  Set it to: 
-utm_source=google&utm_source_platform=Google+Ads&utm_medium=cpc&utm_campaign={_campaignname}&utm_campaignid={campaignid}
+utm_source=google&utm_source_platform=Google+Ads&utm_medium=cpc&utm_campaign={_campaignname}&utm_id={campaignid}
 
 **If you are using a tracking tool**, check on your account at every level, where the “final url suffix” field is already filled out. We recommend using [Google Ads Editor](https://support.google.com/google-ads/editor/answer/2484521?hl=en) to check this quickly. 
 
@@ -52,12 +52,12 @@ If some final url suffix is filled, just [download a bulksheet](https://support.
 If they are not using the final URL suffix yet, make sure you set-up a final url suffix at the account level. 
 
 In your bulksheet, add the UTM parameters after your existing final URL suffix:
-*"&utm_source=google&utm_source_platform=Google+Ads&utm_medium=cpc&utm_campaign={_campaignname}&utm_campaignid={campaignid}"*
+*"&utm_source=google&utm_source_platform=Google+Ads&utm_medium=cpc&utm_campaign={_campaignname}&utm_id={campaignid}"*
 
 Example: 
 - Final URL suffix is already set to “a=1&b=2”.
 - Just add after the utm parameters for Google Analytics:
-- a=1&b=2*&utm_source=google&utm_source_platform=Google+Ads&utm_medium=cpc&utm_campaign={_campaignname}&utm_campaignid={campaignid}*
+- a=1&b=2*&utm_source=google&utm_source_platform=Google+Ads&utm_medium=cpc&utm_campaign={_campaignname}&utm_id={campaignid}*
 
 **Note that we recommend adding the URL suffix at the highest possible level.**
 


### PR DESCRIPTION
The Problem: The current README suggests using the following string:

utm_source=google&utm_source_platform=Google+Ads&utm_medium=cpc&utm_campaign={_campaignname}&utm_campaignid={campaignid} The parameter utm_campaignid is not the standard parameter supported by Google Analytics 4 (GA4) for importing campaign ID data.

The Solution: The correct, GA4-supported parameter for this value is utm_id.

This PR updates the string in the README.md to:

utm_source=google&utm_source_platform=Google+Ads&utm_medium=cpc&utm_campaign={_campaignname}&utm_id={campaignid} This change ensures that users who copy the example string will have their campaign IDs correctly recognized and processed by GA4.